### PR TITLE
Add generateBoth flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * Updated web3j to latest version 4.12.0 [#111](https://github.com/hyperledger/web3j-cli/pull/111)
+* Add generateBoth flag [#114](https://github.com/hyperledger/web3j-cli/pull/114)
 
 ### BREAKING CHANGES
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ plugins {
     id "de.undercouch.download" version "4.1.2"
     id "de.marcphilipp.nexus-publish" version "0.4.0"
     id 'io.codearte.nexus-staging' version '0.30.0'
-    id "com.jfrog.bintray" version "1.8.4"
 }
 
 description 'Web3j command line tools'
@@ -29,7 +28,7 @@ ext {
     wireMockVersion = '3.6.0'
     kotlinLoggin = '3.0.5'
     dockerJavaVersion = '3.3.6'
-    web3jEpirusVersion = '0.0.7'
+    web3jEpirusVersion = '0.0.6'
     log4jVersion = '2.23.1'
     semverVersion = '0.10.2'
     commonsLangVersion = '3.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ plugins {
     id "de.undercouch.download" version "4.1.2"
     id "de.marcphilipp.nexus-publish" version "0.4.0"
     id 'io.codearte.nexus-staging' version '0.30.0'
+    // TODO decide if kept or not
+    // id "com.jfrog.bintray" version "1.8.4"
 }
 
 description 'Web3j command line tools'
@@ -33,6 +35,8 @@ ext {
     semverVersion = '0.10.2'
     commonsLangVersion = '3.14.0'
     jansiVersion = '2.4.1'
+    kotlinPoetVersion = '1.18.1'
+    javaPoetVersion = '1.13.0'
 }
 
 
@@ -57,7 +61,6 @@ apply {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
     mavenLocal()
     maven { url "https://dl.bintray.com/ethereum/maven/" }
@@ -90,6 +93,8 @@ dependencies {
             "org.web3j:hosted-providers:$web3jVersion",
             "io.epirus:epirus-web3j:$web3jEpirusVersion",
             "info.picocli:picocli:$picocli",
+            "com.squareup:kotlinpoet:$kotlinPoetVersion",
+            "com.squareup:javapoet:$javaPoetVersion",
             files('libs/smartcheck.jar'),
             "com.google.code.gson:gson:$gsonVersion",
             "org.apache.commons:commons-lang3:$commonsLangVersion",

--- a/src/main/java/org/web3j/console/wrapper/subcommand/SolidityGenerateCommand.java
+++ b/src/main/java/org/web3j/console/wrapper/subcommand/SolidityGenerateCommand.java
@@ -14,6 +14,7 @@ package org.web3j.console.wrapper.subcommand;
 
 import java.io.File;
 
+import org.web3j.tx.Contract;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -94,6 +95,11 @@ public class SolidityGenerateCommand implements Runnable {
             description = "Use Java primitive types.")
     private boolean primitiveTypes = false;
 
+    @Option(
+            names = {"-B", "--generateBoth"},
+            description = "Generate both send_ and call_ functions.")
+    private boolean generateBoth = false;
+
     @Override
     public void run() {
         try {
@@ -111,7 +117,10 @@ public class SolidityGenerateCommand implements Runnable {
                             packageName,
                             useJavaTypes,
                             primitiveTypes,
-                            addressLength)
+                            generateBoth,
+                            Contract.class,
+                            addressLength,
+                            false)
                     .generate();
         } catch (Exception e) {
             exitError(e);

--- a/src/main/java/org/web3j/console/wrapper/subcommand/SolidityGenerateCommand.java
+++ b/src/main/java/org/web3j/console/wrapper/subcommand/SolidityGenerateCommand.java
@@ -14,7 +14,6 @@ package org.web3j.console.wrapper.subcommand;
 
 import java.io.File;
 
-import org.web3j.tx.Contract;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -22,6 +21,7 @@ import org.web3j.abi.datatypes.Address;
 import org.web3j.codegen.Console;
 import org.web3j.codegen.SolidityFunctionWrapperGenerator;
 import org.web3j.console.Web3jVersionProvider;
+import org.web3j.tx.Contract;
 
 import static org.web3j.codegen.Console.exitError;
 import static picocli.CommandLine.Help.Visibility.ALWAYS;


### PR DESCRIPTION
As described in [this issue](https://github.com/hyperledger/web3j-cli/issues/113), our company needs the `generateBoth` option in order to use the` web3j-cli`. I made the required changes for that. Please review and let me know what do you think.

Also, I updated some dependencies because the project did not compile locally.